### PR TITLE
Update steps for the quickstart tutorial

### DIFF
--- a/source/tutorials/quickstart.rst
+++ b/source/tutorials/quickstart.rst
@@ -20,6 +20,10 @@ In a new console window, cd to the NATS test directory in the Linux for Health c
 
    cd connect/src/test/resources/nats
 
+Ensure that the NodeJS dependencies are installed::
+
+   npm install
+
 Run the subscriber::
 
    node nats-subscriber


### PR DESCRIPTION
The quickstart tutorial was missing a step for installing the NodeJS dependencies (src/test/resources/nats/package.json).